### PR TITLE
Fix NPC idle animation override in zadLibs.psc

### DIFF
--- a/00 Core/scripts/Source/zadLibs.psc
+++ b/00 Core/scripts/Source/zadLibs.psc
@@ -2126,7 +2126,7 @@ int Function VibrateEffect(actor akActor, int vibStrength, int duration, bool te
 		;;;;;;;;;;
 		; Play horny idle?
 		;;;;;;;;;;
-		if (vibAnimStarted == 0) && Utility.RandomInt() <= (3+(VibStrength * 2)) && !IsAnimating(PlayerRef)
+		if (vibAnimStarted == 0) && Utility.RandomInt() <= (3+(VibStrength * 2)) && !IsAnimating(akActor)
 			; Log("XXX Starting Horny Idle")
 			ApplyExpression(akActor, expression, (Aroused.GetActorExposure(akActor) * 0.75) as Int, openMouth=true)
 			; Select animation


### PR DESCRIPTION
"if is frame 0 and has a chance to play and the player is not being animated"
this will trigger for a NPC even if he is being animated replacing his animation unless the player is in animation as well.
changing to "akActor" will check the animation against the current actor that will play the animation.
@greyspammer