### PR TITLE
ResetExternalAA was missing FNIS Sexy Move 360 pack implementation

### DIFF
--- a/00 Core/scripts/Source/zadBoundCombatScript.psc
+++ b/00 Core/scripts/Source/zadBoundCombatScript.psc
@@ -284,13 +284,20 @@ Function ResetExternalAA(actor akActor)
 			If libs.playerref.GetLeveledActorBase().GetSex() != 1
 				return
 			Endif
-			FNISSMConfigMenu FNISSM = Game.GetFormFromFile(0x000012C7, "FNISSexyMove.esp") As FNISSMConfigMenu			
-			int SM = FNISSM.FNISSMquest.iSMplayer 						
+			FNISSMConfigMenu FNISSM = Game.GetFormFromFile(0x000012C7, "FNISSexyMove.esp") As FNISSMConfigMenu
+			int SM = FNISSM.FNISSMquest.iSMplayer
 			if SM == 0
 				FNIS_aa.SetAnimGroup(Game.GetPlayer(), "_mt", 0, 0, "FNIS Sexy Move", true)
+				FNIS_aa.SetAnimGroup(Game.GetPlayer(), "_mtx", 0, 0, "FNIS Sexy Move", true)
 			else
-				FNIS_aa.SetAnimGroup(Game.GetPlayer(), "_mt", FNISSM.FNISSMQuest.FNISsmMtBase, SM - 1, "FNIS Sexy Move", true)
-			endif					
+				if FNISSM.FNISSMquest.FNISs3ModID >= 0 && FNISSM.FNISSMquest.SM360 ; 360 pack installed and activated
+					FNIS_aa.SetAnimGroup(Game.GetPlayer(), "_mt", FNISSM.FNISSMquest.FNISs3MtBase, SM - 1, "FNIS Sexy Move(360)", true)
+					FNIS_aa.SetAnimGroup(Game.GetPlayer(), "_mtx", FNISSM.FNISSMquest.FNISs3MtxBase, SM - 1, "FNIS Sexy Move(360)", true)
+				else
+					FNIS_aa.SetAnimGroup(Game.GetPlayer(), "_mt", FNISSM.FNISSMquest.FNISsmMtBase, SM - 1, "FNIS Sexy Move", true)
+					FNIS_aa.SetAnimGroup(Game.GetPlayer(), "_mtx", FNISSM.FNISSMquest.FNISsmMtxBase, SM - 1, "FNIS Sexy Move", true)
+				endif
+			endif
 		Endif
 	EndIf
 EndFunction


### PR DESCRIPTION
The ResetExternalAA function was not resetting FNIS Sexy Move 360 pack animations due to it not being implemented in the function. This caused ResetExternalAA to reset the walk/run animations to regular Sexy Move animations, cancelling out the currently selected 360 pack animations.

The only other way around this was going into the FNIS Sexy Move MCM and manually toggling off/on the 360 pack every time it was reset.

This pull request fixes that by adding the appropriate SetAnimGroup calls to ResetExternalAA.